### PR TITLE
Audit - APEX 483 - SignTx cardano-api endpoint potential security issues

### DIFF
--- a/cardano-api/api/model/request/sign_bridging_tx_request.go
+++ b/cardano-api/api/model/request/sign_bridging_tx_request.go
@@ -1,8 +1,0 @@
-package request
-
-type SignBridgingTxRequest struct {
-	SigningKeyHex string `json:"signingKey"`
-	NetworkID     uint   `json:"networkID"`
-	TxRaw         string `json:"txRaw"`
-	TxHash        string `json:"txHash"`
-}


### PR DESCRIPTION
removed cardano-api signTx endpoint as it is not used, and can cause security issues

Issue description:
5.2.0 P2 - Concurrent call to `signTx` can cause security issues
Component: cardano_tx_controller.go
Reference: [link](https://github.com/Ethernal-Tech/apex-web/blob/64daa5b2775ea41bb97e0b88438252edea9ba52c/cardano-api/api/controllers/cardano_tx_controller.go#L228)
Category: Security Issue

`signTx` if called concurrently by many issuers can cause wrong transactions to be returned or even signed because the library reads and writes to the same file for each request by calling the `cardano-cli` command. The system can acquire wrong transactions. Attackers can steal un-submitted signed transactions. This issue can be easily mitigated by creating files with dedicated names per request.