### PR TITLE
Audit - APEX 489 - Wrong API exception used

### DIFF
--- a/web-api/src/transaction/transaction.helper.ts
+++ b/web-api/src/transaction/transaction.helper.ts
@@ -9,7 +9,11 @@ import {
 	CardanoTransactionFeeResponseDto,
 } from './transaction.dto';
 import axios, { AxiosError } from 'axios';
-import { BadRequestException, Logger } from '@nestjs/common';
+import {
+	BadRequestException,
+	InternalServerErrorException,
+	Logger,
+} from '@nestjs/common';
 import web3, { Web3 } from 'web3';
 import { isAddress } from 'web3-validator';
 import { NewAddress, RewardAddress } from 'src/utils/Address/addreses';
@@ -151,7 +155,7 @@ export const createEthBridgingTx = async (
 	const destMinFee =
 		bridgingSettings.minChainFeeForBridging[dto.destinationChain];
 	if (!destMinFee) {
-		throw new BadRequestException(
+		throw new InternalServerErrorException(
 			`No minFee for destination chain: ${dto.destinationChain}`,
 		);
 	}


### PR DESCRIPTION
switched error from BadRequest to InternalServerError in one spot

Issue description:
5.4.3 P4 -  `BadRequestException` message points to a user error instead of the internal server error
Component: transaction.helper.ts
Reference: [link](https://github.com/Ethernal-Tech/apex-web/blob/64daa5b2775ea41bb97e0b88438252edea9ba52c/web-api/src/transaction/transaction.helper.ts#L155)
Category: Code Style / Misleading

The `BadRequestException` message “No minFee for destination chain” after already validated input and output chain should result in InternalServerError. The chain setting does not exist due to operator error, not user error.