### PR TITLE
Audit - APEX 490 -  validateCreateCardanoTx does not validate the bridging fee

### DIFF
--- a/web-api/src/transaction/transaction.service.ts
+++ b/web-api/src/transaction/transaction.service.ts
@@ -73,6 +73,24 @@ export class TransactionService {
 		) {
 			throw new BadRequestException('Invalid destination chain');
 		}
+
+		const destMinFee =
+			this.settingsService.BridgingSettings.minChainFeeForBridging[
+				dto.destinationChain
+			];
+		if (!destMinFee) {
+			throw new InternalServerErrorException(
+				`No minFee for destination chain: ${dto.destinationChain}`,
+			);
+		}
+
+		const minBridgingFee = BigInt(destMinFee);
+		const bridgingFee = BigInt(dto.bridgingFee || '0');
+		if (bridgingFee !== BigInt(0) && bridgingFee < minBridgingFee) {
+			throw new BadRequestException(
+				'Bridging fee in request body is less than minimum',
+			);
+		}
 	}
 
 	async createCardano(


### PR DESCRIPTION
validated minBridgingFee on web-api also

Issue description:
5.4.4 P4 - `validateCreateCardanoTx`  does not validate the bridging fee
Component: transaction.service.ts
Reference: [link](https://github.com/Ethernal-Tech/apex-web/blob/64daa5b2775ea41bb97e0b88438252edea9ba52c/web-api/src/transaction/transaction.service.ts#L54)
Category: Code Style / Validation

The `validateCreateCardanoTx` does not validate the bridging fee amount if submitted for both cases where the validation is called. Users could provide lower than allowable amounts resulting in needless proxy calls towards Cardano API.