### PR TITLE
Audit - APEX 491 - APIKeyAuth could be converted to NoAuth

### DIFF
--- a/cardano-api/api/api.go
+++ b/cardano-api/api/api.go
@@ -47,7 +47,7 @@ func NewAPI(
 			endpointPath := fmt.Sprintf("/%s/%s/%s", apiConfig.PathPrefix, controllerPathPrefix, endpoint.Path)
 
 			endpointHandler := endpoint.Handler
-			if endpoint.APIKeyAuth {
+			if !endpoint.NoAPIKeyAuth {
 				endpointHandler = withAPIKeyAuth(apiConfig, endpointHandler, logger)
 			}
 

--- a/cardano-api/api/controllers/cardano_tx_controller.go
+++ b/cardano-api/api/controllers/cardano_tx_controller.go
@@ -45,9 +45,9 @@ func (*CardanoTxControllerImpl) GetPathPrefix() string {
 
 func (c *CardanoTxControllerImpl) GetEndpoints() []*core.APIEndpoint {
 	return []*core.APIEndpoint{
-		{Path: "CreateBridgingTx", Method: http.MethodPost, Handler: c.createBridgingTx, APIKeyAuth: true},
-		{Path: "GetBridgingTxFee", Method: http.MethodPost, Handler: c.getBridgingTxFee, APIKeyAuth: true},
-		{Path: "GetBalance", Method: http.MethodGet, Handler: c.getBalance, APIKeyAuth: true},
+		{Path: "CreateBridgingTx", Method: http.MethodPost, Handler: c.createBridgingTx},
+		{Path: "GetBridgingTxFee", Method: http.MethodPost, Handler: c.getBridgingTxFee},
+		{Path: "GetBalance", Method: http.MethodGet, Handler: c.getBalance},
 	}
 }
 

--- a/cardano-api/core/data.go
+++ b/cardano-api/core/data.go
@@ -7,10 +7,10 @@ import (
 type APIEndpointHandler = func(w http.ResponseWriter, r *http.Request)
 
 type APIEndpoint struct {
-	Path       string
-	Method     string
-	Handler    APIEndpointHandler
-	APIKeyAuth bool
+	Path         string
+	Method       string
+	Handler      APIEndpointHandler
+	NoAPIKeyAuth bool
 }
 
 type SettingsResponse struct {


### PR DESCRIPTION
inverted logic for requiring api key, so that endpoints require it by default

Issue description:
5.4.5 P4 - `APIKeyAuth` could be converted to `NoAuth`
Component: data.go
Reference: [link](https://github.com/Ethernal-Tech/apex-web/blob/64daa5b2775ea41bb97e0b88438252edea9ba52c/cardano-api/core/data.go#L13)
Category: Code style / Safeguarding

APIKeyAuth can be replaced with NoAuth so the requiring the auth is a default setting.