### PR TITLE
Wallet account change fix

### DIFF
--- a/frontend/src/pages/Transactions/NewTransactionPage.tsx
+++ b/frontend/src/pages/Transactions/NewTransactionPage.tsx
@@ -51,7 +51,7 @@ function NewTransactionPage() {
 	}, [navigate]);
 
 	const prepareCreateCardanoTx = useCallback(async(address: string, amount: string, isNativeToken: boolean = false): Promise<CreateTransactionDto> => {
-    await walletHandler.getChangeAddress(); // check if the account has changed
+    	await walletHandler.getChangeAddress(); // this line triggers an error if the wallet account has been changed by the user in the meantime
 
 		return new CreateTransactionDto({
 			bridgingFee: '0', // will be set on backend


### PR DESCRIPTION
This PR includes a fix for handling account or network changes in the Eternl wallet after the initial connection is established.

The issue can occur after the wallet connection is established but before a transaction is sent. During this time, the user may switch between different networks or different accounts, which can cause a mismatch between the connected account address and the temporary wallet address.

To fix this bug, we added an additional check that compares the address stored in the application state with the temporary address from the wallet during transaction creation. If the address has changed, we also verify whether the network has changed. Depending on whether only the account or the entire network has changed, we throw the appropriate error.