### PR TITLE
Fix explorer button linked to testnet instead of mainnet

### DIFF
--- a/frontend/src/pages/Transactions/components/TransferProgress.tsx
+++ b/frontend/src/pages/Transactions/components/TransferProgress.tsx
@@ -8,7 +8,7 @@ import { useNavigate } from "react-router-dom"
 import { BridgeTransactionDto, ChainEnum, TransactionStatusEnum } from "../../../swagger/apexBridgeApiService"
 import { FunctionComponent, SVGProps, useEffect, useMemo, useState } from "react"
 import { capitalizeWord } from "../../../utils/generalUtils"
-import { openExplorer } from "../../../utils/chainUtils"
+import { isExplorerExist, openExplorer } from "../../../utils/chainUtils"
 // import {ReactComponent as ErrorIcon} from "../../../assets/bridge-status-icons/error.svg"
 
 // asset svgs
@@ -302,6 +302,7 @@ const TransferProgress = ({
                 <ButtonCustom  
                     variant="white" 
                     onClick={onOpenExplorer}
+                    disabled={!isExplorerExist(tx)}
                     sx={{ gridColumn:'span 1', textTransform:'uppercase'}}>
                     View Explorer
                 </ButtonCustom>

--- a/frontend/src/pages/Transactions/components/TransferProgress.tsx
+++ b/frontend/src/pages/Transactions/components/TransferProgress.tsx
@@ -8,7 +8,7 @@ import { useNavigate } from "react-router-dom"
 import { BridgeTransactionDto, ChainEnum, TransactionStatusEnum } from "../../../swagger/apexBridgeApiService"
 import { FunctionComponent, SVGProps, useEffect, useMemo, useState } from "react"
 import { capitalizeWord } from "../../../utils/generalUtils"
-import { isExplorerExist, openExplorer } from "../../../utils/chainUtils"
+import { getExplorerUrl, openExplorer } from "../../../utils/chainUtils"
 // import {ReactComponent as ErrorIcon} from "../../../assets/bridge-status-icons/error.svg"
 
 // asset svgs
@@ -302,7 +302,7 @@ const TransferProgress = ({
                 <ButtonCustom  
                     variant="white" 
                     onClick={onOpenExplorer}
-                    disabled={!isExplorerExist(tx)}
+                    disabled={!getExplorerUrl(tx)}
                     sx={{ gridColumn:'span 1', textTransform:'uppercase'}}>
                     View Explorer
                 </ButtonCustom>

--- a/frontend/src/utils/chainUtils.ts
+++ b/frontend/src/utils/chainUtils.ts
@@ -100,6 +100,8 @@ const EXPLORER_URLS: {mainnet: {[key: string]: string}, testnet: {[key: string]:
 
 const getExplorerTxUrl = (chain: ChainEnum, txHash: string) => {
     const base = appSettings.isMainnet ? EXPLORER_URLS.mainnet[chain] : EXPLORER_URLS.testnet[chain];
+
+    if (!base || base.trim() === '') return
     
     let url
     switch (chain) {
@@ -123,7 +125,7 @@ const getExplorerTxUrl = (chain: ChainEnum, txHash: string) => {
     return url;
 }
 
-export const openExplorer = (tx: BridgeTransactionDto | undefined) => {
+export const getExplorerUrl = (tx: BridgeTransactionDto | undefined) => {
     if (!tx) {
         return;
     }
@@ -131,27 +133,22 @@ export const openExplorer = (tx: BridgeTransactionDto | undefined) => {
     if (tx.status === TransactionStatusEnum.ExecutedOnDestination && tx.destinationTxHash) {
         const txHash = tx.destinationChain === ChainEnum.Nexus && !tx.destinationTxHash.startsWith('0x')
             ? `0x${tx.destinationTxHash}` : tx.destinationTxHash;
-        const url = getExplorerTxUrl(tx.destinationChain, txHash)
-        window.open(url, '_blank')
+
+        return getExplorerTxUrl(tx.destinationChain, txHash)
     } else if (tx.sourceTxHash) {
         const txHash = tx.originChain === ChainEnum.Nexus && !tx.sourceTxHash.startsWith('0x')
             ? `0x${tx.sourceTxHash}` : tx.sourceTxHash;
-        const url = getExplorerTxUrl(tx.originChain, txHash)
-        window.open(url, '_blank')
+
+        return getExplorerTxUrl(tx.originChain, txHash)
     }
 }
 
-export const isExplorerExist = (tx: BridgeTransactionDto): boolean => {
-    if (tx.status === TransactionStatusEnum.ExecutedOnDestination && tx.destinationTxHash) {
-        const base = appSettings.isMainnet ? EXPLORER_URLS.mainnet[tx.destinationChain] : EXPLORER_URLS.testnet[tx.destinationChain];
-        return !!base && base.trim() !== '';
-    }else if (tx.sourceTxHash){
-        const base = appSettings.isMainnet ? EXPLORER_URLS.mainnet[tx.destinationChain] : EXPLORER_URLS.testnet[tx.destinationChain];
-        return !!base && base.trim() !== '';
+export const openExplorer = (tx: BridgeTransactionDto | undefined) => {
+    const url = getExplorerUrl(tx);
+    if (url) {
+          window.open(url, '_blank')
     }
-    
-    return false;
-};
+}
 
 export enum TokenEnum {
 	Ada = 'Ada',

--- a/frontend/src/utils/chainUtils.ts
+++ b/frontend/src/utils/chainUtils.ts
@@ -89,7 +89,7 @@ const EXPLORER_URLS: {mainnet: {[key: string]: string}, testnet: {[key: string]:
     mainnet: {
         [ChainEnum.Prime]: 'https://apexscan.org/en',
         [ChainEnum.Vector]: 'https://vector-apex.ethernal.tech',
-        [ChainEnum.Nexus]: 'https://explorer.nexus.testnet.apexfusion.org',
+        [ChainEnum.Nexus]: '',
     },
     testnet: {
         [ChainEnum.Prime]: 'https://prime-apex.ethernal.tech',
@@ -140,6 +140,18 @@ export const openExplorer = (tx: BridgeTransactionDto | undefined) => {
         window.open(url, '_blank')
     }
 }
+
+export const isExplorerExist = (tx: BridgeTransactionDto): boolean => {
+    if (tx.status === TransactionStatusEnum.ExecutedOnDestination && tx.destinationTxHash) {
+        const base = appSettings.isMainnet ? EXPLORER_URLS.mainnet[tx.destinationChain] : EXPLORER_URLS.testnet[tx.destinationChain];
+        return !!base && base.trim() !== '';
+    }else if (tx.sourceTxHash){
+        const base = appSettings.isMainnet ? EXPLORER_URLS.mainnet[tx.destinationChain] : EXPLORER_URLS.testnet[tx.destinationChain];
+        return !!base && base.trim() !== '';
+    }
+    
+    return false;
+};
 
 export enum TokenEnum {
 	Ada = 'Ada',


### PR DESCRIPTION
This PR fixes an issue where the frontend opened the Nexus testnet explorer instead of the mainnet explorer.
Previously, when a transaction was executed on Nexus mainnet, clicking the explorer button would incorrectly open the Nexus testnet explorer.
This fix removes the incorrect testnet URL for Nexus mainnet and disables the explorer button if the corresponding URL is not defined or is an empty string.
